### PR TITLE
Add string.h to avoid compilation errors

### DIFF
--- a/curses_interface.cpp
+++ b/curses_interface.cpp
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <ncurses.h>
 #include <signal.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Add string.h to avoid compilation errors